### PR TITLE
Check format, extent and date in dmdSec

### DIFF
--- a/baroque/baroque_project.py
+++ b/baroque/baroque_project.py
@@ -215,6 +215,7 @@ class BaroqueProject(object):
         item_id_column = "DigFile Calc"
         collection_title_column = "COLLECTIONS::CollectionTitle"
         item_title_column = "ItemTitle"
+        item_date_column = "ItemDate"
 
         export_type = os.path.splitext(metadata_export)[1]
         if export_type in [".csv", ".xlsx"]:
@@ -237,12 +238,14 @@ class BaroqueProject(object):
                 collection_id = self._parse_collection_id(item_id)
                 collection_title = row.get(collection_title_column)
                 item_title = row.get(item_title_column)
+                item_date = row.get(item_date_column)
                 metadata["items_ids"].append(item_id)
                 if collection_id not in metadata["collections_ids"]:
                     metadata["collections_ids"].append(collection_id)
                 metadata["item_metadata"][item_id] = {
                     "collection_title": collection_title,
-                    "item_title": item_title
+                    "item_title": item_title,
+                    "item_date": item_date
                 }
 
         # File type: neither csv nor xlsx

--- a/baroque/mets_validation.py
+++ b/baroque/mets_validation.py
@@ -1,6 +1,7 @@
 import os
 import re
 from lxml import etree
+import dateparser
 
 from .baroque_validator import BaroqueValidator
 
@@ -95,6 +96,16 @@ class MetsValidator(BaroqueValidator):
             exist = False
 
         return subelements, exist
+
+    def check_dates(self, metadata_date, mets_date):
+        if metadata_date == "Undated" and mets_date == "undated":
+            pass
+        if dateparser.parse(metadata_date) != dateparser.parse(mets_date):
+            self.error(
+                    self.path_to_mets,
+                    self.item_id,
+                    metadata_date + ' date in metadata does not equal ' + mets_date + ' date in mets'
+                )
 
     
     def check_subelement_exists(self, element, subelement_path):
@@ -209,7 +220,7 @@ class MetsValidator(BaroqueValidator):
 
                         dc_date, exists = self.check_subelement_exists(xmlData, "dc:date")
                         if exists:
-                            self.check_tag_text(dc_date, "Is", self.item_metadata["item_date"])
+                            self.check_dates(self.item_metadata["item_date"], dc_date.text)
 
                         dc_format, exists = self.check_subelement_exists(xmlData, "dc:format")
 

--- a/baroque/mets_validation.py
+++ b/baroque/mets_validation.py
@@ -98,14 +98,18 @@ class MetsValidator(BaroqueValidator):
         return subelements, exist
 
     def check_dates(self, metadata_date, mets_date):
+        metadata_date = self.sanitize_text(metadata_date)
         if metadata_date == "Undated" and mets_date == "undated":
             pass
-        if dateparser.parse(metadata_date) != dateparser.parse(mets_date):
+        # Trying to get around character encoding issues at the end of dates discovered during testing
+        if dateparser.parse(metadata_date) == dateparser.parse(mets_date) or dateparser.parse(metadata_date[:-1]) == dateparser.parse(mets_date):
+            pass
+        else:
             self.error(
                     self.path_to_mets,
                     self.item_id,
                     metadata_date + ' date in metadata does not equal ' + mets_date + ' date in mets'
-                )
+            )
 
     
     def check_subelement_exists(self, element, subelement_path):

--- a/baroque/mets_validation.py
+++ b/baroque/mets_validation.py
@@ -212,6 +212,8 @@ class MetsValidator(BaroqueValidator):
                             self.check_tag_text(dc_date, "Is", self.item_metadata["item_date"])
 
                         dc_format, exists = self.check_subelement_exists(xmlData, "dc:format")
+
+                        dc_format_extent, exists = self.check_subelements_exist(xmlData, "dc:format.extent")
             else:
                 self.warn(
                     self.path_to_mets,

--- a/baroque/mets_validation.py
+++ b/baroque/mets_validation.py
@@ -206,6 +206,10 @@ class MetsValidator(BaroqueValidator):
                         dc_identifier, exists = self.check_subelement_exists(xmlData, "dc:identifier")
                         if exists:
                             self.check_tag_text(dc_identifier, "Is", self.item_id)
+
+                        dc_date, exists = self.check_subelement_exists(xmlData, "dc:date")
+                        if exists:
+                            self.check_tag_text(dc_date, "Is", self.item_metadata["item_date"])
             else:
                 self.warn(
                     self.path_to_mets,

--- a/baroque/mets_validation.py
+++ b/baroque/mets_validation.py
@@ -102,9 +102,7 @@ class MetsValidator(BaroqueValidator):
         if metadata_date == "Undated" and mets_date == "undated":
             pass
         # Trying to get around character encoding issues at the end of dates discovered during testing
-        if dateparser.parse(metadata_date) == dateparser.parse(mets_date) or dateparser.parse(metadata_date[:-1]) == dateparser.parse(mets_date):
-            pass
-        else:
+        if dateparser.parse(metadata_date) != dateparser.parse(mets_date) and dateparser.parse(metadata_date[:-1]) != dateparser.parse(mets_date):
             self.error(
                     self.path_to_mets,
                     self.item_id,

--- a/baroque/mets_validation.py
+++ b/baroque/mets_validation.py
@@ -210,6 +210,8 @@ class MetsValidator(BaroqueValidator):
                         dc_date, exists = self.check_subelement_exists(xmlData, "dc:date")
                         if exists:
                             self.check_tag_text(dc_date, "Is", self.item_metadata["item_date"])
+
+                        dc_format, exists = self.check_subelement_exists(xmlData, "dc:format")
             else:
                 self.warn(
                     self.path_to_mets,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ et-xmlfile==1.0.1
 jdcal==1.4.1
 lxml==4.4.1
 openpyxl==2.6.3
+dateparser==0.7.2


### PR DESCRIPTION
Changes proposed in this pull request include those we discussed in our Sprint 2 check-in meeting on Tue, Oct 8:
- Check if `dc:format` exists in `dmdSec`
- Check if at least one `dc:format.extent` exists
- Check if `dc:date` exists and if its value matches what's in the spreadsheet

For the last one, I did some analysis just to see what would happen if we just tried to match the date strings, and found the following types of errors:
- undated in the metadata to Undated in the METS
- MM/DD/YYYY to YYYY Month DD
- MM/DD/YYYY to Month DD, YYYY
- Character encoding issues originating in the BEAL export

The first one was easy to account for with a basic check. The next two were easy to account for using [dateparser](https://dateparser.readthedocs.io/en/latest/) (and thanks for the idea, Dallas). The last one I accounted for with some string manipulation (the weird character was always at the end of the date string, so first I check the string, then I check the string minus the last character). Not perfect but seems like it works.

Before submitting a pull request, confirm that the following steps have been taken:
- [ ] Added unit tests
- [x] Updated documentation (at least the requirements.txt file)

Tag someone who should review this pull request:
@djpillen @umadair 
