### PR TITLE
add more resilient checks to address traceback errors

### DIFF
--- a/baroque/baroque_project.py
+++ b/baroque/baroque_project.py
@@ -69,6 +69,7 @@ class BaroqueProject(object):
         self.source_directory = source_directory
         self.destination_directory = destination_directory
         self.metadata_export = metadata_export
+        self.errors = {}
 
         if self.metadata_export:
             self.metadata = self.parse_metadata_export(metadata_export)
@@ -85,8 +86,6 @@ class BaroqueProject(object):
             self.parse_collection(source_directory)
         elif self.source_type == "item":
             self.parse_item(source_directory)
-
-        self.errors = {}
 
     def characterize_source_directory(self):
         """
@@ -184,11 +183,15 @@ class BaroqueProject(object):
             if other is True:
                 files["other"].append(file)
 
-        self.items.append({
-            "id": os.path.basename(item_directory),
-            "path": item_directory,
-            "files": files
-        })
+        if len(files["wav"]) > 0 or len(files["mp3"]) > 0:
+            self.items.append({
+                "id": os.path.basename(item_directory),
+                "path": item_directory,
+                "files": files
+            })
+        else:
+            self.errors["baroque_project"] = []
+            self.add_errors("baroque_project", "warning", item_directory, os.path.basename(item_directory), "item directory does not appear to be an audio recording")
     
     def _parse_collection_id(self, item_id):
         return item_id.split("-")[0] # NOTE: Collection IDs are parsed from item IDs


### PR DESCRIPTION
Changes proposed in this pull request included:
- In `baroque_project.py`, if an item does not have any .wav or .mp3 files, do not add it to the project's `items` list and log a warning that the directory does not appear to be an audio recording
- In `mets_validation.py`, make checks for tag attribute values more resilient by first checking if an attribute exists before checking its value
- In `mets_validation.py`, make `sanitize_text` more resilient by only making regular expression substitutions when text is not `None`.

Each of these changes was made in response to various traceback errors reported during Sprint 2 testing. The errors were all a result of certain unchecked assumptions that BAroQUe was making: assuming that all directories were audio recordings, assuming that collection titles and item dates were present in the metadata spreadsheet, and so on.

Tag someone who should review this pull request:
@eckardm 
