### PR TITLE
fix encoding and NoneType errors in wav bext chunk validation

### DIFF
--- a/baroque/mets_validation.py
+++ b/baroque/mets_validation.py
@@ -6,6 +6,7 @@ import sys
 from tqdm import tqdm
 
 from .baroque_validator import BaroqueValidator
+from .utils import sanitize_text
 
 # Note: Some namespaces referenced in the example XML files are not used in the METS file. Unless I'm missing some, these are: fits, fn, rights, marc21 and  tcf.
 namespaces = {
@@ -24,22 +25,11 @@ class MetsValidator(BaroqueValidator):
         validator = self.validate_mets
         super().__init__(validation, validator, project)
 
-    def sanitize_text(self, text):
-        """
-        Helper function to remove newlines and extra spaces from a string"""
-        if text is None:
-            return ""
-        else:
-            text = re.sub(r"\n", " ", text)
-            text = re.sub(r"\s+", " ", text)
-            text = text.strip()
-            return text
-
     def check_tag_text(self, tag, argument, value=None):
         """
         Helper function to check an element's value against an expected value"""
-        tag_text = self.sanitize_text(tag.text)
-        value = self.sanitize_text(value)
+        tag_text = sanitize_text(tag.text)
+        value = sanitize_text(value)
         if argument == "Is":
             if tag_text != value:
                 self.error(
@@ -137,7 +127,7 @@ class MetsValidator(BaroqueValidator):
     def check_dates(self, metadata_date, mets_date):
         """
         Helper function that compares dates from a metadata spreadsheet and METS XML"""
-        metadata_date = self.sanitize_text(metadata_date)
+        metadata_date = sanitize_text(metadata_date)
         if metadata_date == "Undated" and mets_date == "undated":
             pass
         # Trying to get around character encoding issues at the end of dates discovered during testing

--- a/baroque/report_generation.py
+++ b/baroque/report_generation.py
@@ -21,7 +21,7 @@ def generate_reports(baroqueproject):
         csv_filename = source + "-" + date + ".csv"
         csv_filepath = os.path.join(baroqueproject.destination_directory, csv_filename)
 
-        with open(csv_filepath, 'w', newline='') as csvfile:
+        with open(csv_filepath, 'w', newline='', encoding="utf-8") as csvfile:
             # Define and write header row values of csv file.
             fieldnames = ['validation', 'error_type', 'path', 'id', 'error']
             writer = csv.DictWriter(csvfile, fieldnames=fieldnames)

--- a/baroque/utils.py
+++ b/baroque/utils.py
@@ -1,0 +1,14 @@
+import re
+
+
+def sanitize_text(text):
+    """
+    Helper function to remove newlines and extra spaces from a string"""
+    if text is None:
+        return ""
+    else:
+        text = re.sub(r"\n", " ", text)
+        text = re.sub(r"\s+", " ", text)
+        text = text.replace('“', '"').replace('”', '"')
+        text = text.strip()
+        return text


### PR DESCRIPTION
Changes proposed in this pull request included:
- check if an item has metadata before trying to validate the metadata against the WAV BEXT chunk
- separate out the `sanitize_text` function from `mets_validation.py` into a new `utils.py` file and add a line to replace curly quotes with straight quotes
- use the `sanitize_text` function in `wav_bext_chunk_validation.py` to compare values from the metadata spreadsheet and WAV metadata
- open the CSV error report with unicode encoding (`encoding="utf-8"`) to avoid encoding errors when writing the CSV

These changes resolve various traceback errors that were reported during Sprint 3 testing.

Tag someone who should review this pull request:
@eckardm 
