### PR TITLE
CodingHistory validation, configurable reports and some other stuff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 __pycache__
 /venv/
 .vscode
+config.ini
+reports/

--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ Not yet implemented.
 ### config.ini
 An optional `config.ini` file can be supplied in the top-level `baroque` directory to supply BAroQUe with a path to a destination directory where reports will be saved and various tools. See `config-sample.ini` for an example of what this file should look like.
 
+```ini
+[reports]
+path=path\to\reports
+
+[bwf_metaedit]
+path=path\to\bwfmetaedit.exe
+```
+
 ## General Functionality
 
 ### BaroqueProject

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ The **Bentley Audiovisual Quality control Utility (BAroQUe)** is a Python 3-base
 ## Usage
 BAroQUe's functionality is implemented in `baroque.py`, which is a command line script that takes as its input a minimum of 3 arguments:
 - The path to a source_directory that corresponds to either a shipment, a collection, or an item directory
-- The path to a destination directory where reports and logs will be stored
+- An optional argument (`-d, --destination`) with a path to a destination directory where reports and logs will be stored. In the absence of this argument, BAroQUe checks the `config.ini` file for the path to a destination directory. Failing that, BAroQUe defaults to a `/reports` directory.
 - The validation action to be run against the source directory
 
-Certain validation actions (`structure`, `mets` and `wav`) require a fourth argument: the path to a metadata export to validate against. BAroQUe expects this metadata export to contain at least the following column headers: "DigFile Calc", CollectionTitle", "ItemTitle", and "ItemDate".
+Certain validation actions (`structure`, `mets` and `wav`) require a fourth argument: the path to a metadata export (CSV or XLSX) to validate against. BAroQUe expects this metadata export to contain at least the following column headers: "DigFile Calc", CollectionTitle", "ItemTitle", and "ItemDate".
 
 A summary of the available validation actions are below, followed by detailed instructions for each validation.
 
@@ -35,7 +35,7 @@ A summary of the available validation actions are below, followed by detailed in
 An example command to validate directory and file structure for a shipment-level directory might look like:
 
 ```sh
-$ baroque.py /path/to/shipment /path/to/reports -s -e /path/to/metadata/export
+$ baroque.py /path/to/shipment -d /path/to/reports -s -e /path/to/metadata/export
 ```
 
 ### Validate directory and file structure
@@ -44,12 +44,11 @@ This step validates the directory and file structure of the supplied source dire
 | Argument | Help |
 | --- | --- |
 | SOURCE_DIR | Path to a source directory (a shipment, collection, or item) |
-| DESTINATION_DIR | Path to a destination directory where reports will be saved |
 | -s, --structure | Validate directory and file structure |
 | -e, --export | Path to a metadata export (CSV or .xlsx) |
 
 ```sh
-$ baroque.py SOURCE_DIR DESTINATION_DIR -s/--structure -e/--export PATH
+$ baroque.py SOURCE_DIR -s/--structure -e/--export PATH
 ```
 
 ### Validate METS XML
@@ -58,26 +57,24 @@ This step validates the METS XML for each item. This includes validating that va
 | Argument | Help |
 | --- | --- |
 | SOURCE_DIR | Path to a source directory (a shipment, collection, or item) |
-| DESTINATION_DIR | Path to a destination directory where reports will be saved |
 | -m, --mets | Validate METS XML |
 | -e, --export | Path to a metadata export (CSV or .xlsx) |
 
 ```sh
-$ baroque.py SOURCE_DIR DESTINATION_DIR -m/--mets -e/export PATH
+$ baroque.py SOURCE_DIR -m/--mets -e/export PATH
 ```
 
 ### Validate WAV BEXT chunks
-This step validates each WAV file in an item's embedded BEXT chunk. THis includes validating that various bits of metadata exist (e.g., `TimeReference` and `CodingHistory`), that the value of various bits of metadata match what's expected (e.g., that `Description` matches the `ItemTitle` field in the metadata export and that `OriginatorReference` follows the appropriate convention) and that various bits of metadata can be recognized as times or dates (e.g., `OriginationTime` and `OriginationDate`).
+This step validates each WAV file in an item's embedded BEXT chunk. This includes validating that various bits of metadata exist (e.g., `TimeReference` and `CodingHistory`), that the value of various bits of metadata match what's expected (e.g., that `Description` matches the `ItemTitle` field in the metadata export and that `OriginatorReference` follows the appropriate convention) and that various bits of metadata can be recognized as times or dates (e.g., `OriginationTime` and `OriginationDate`).
 
 | Argument | Help |
 | --- | --- |
 | SOURCE_DIR | Path to a source directory (a shipment, collection, or item) |
-| DESTINATION_DIR | Path to a destination directory where reports will be saved |
 | -w, --wav | Validate WAV BEXT chunk |
 | -e, --export | Path to a metadata export (CSV or .xlsx) |
 
 ```sh
-$ baroque.py SOURCE_DIR DESTINATION_DIR -m/--mets -e/export PATH
+$ baroque.py SOURCE_DIR -m/--mets -e/export PATH
 ```
 
 ### Validate files
@@ -85,6 +82,9 @@ Not yet implemented.
 
 ### Validate checksums
 Not yet implemented.
+
+### config.ini
+An optional `config.ini` file can be supplied in the top-level `baroque` directory to supply BAroQUe with a path to a destination directory where reports will be saved and various tools. See `config-sample.ini` for an example of what this file should look like.
 
 ## General Functionality
 

--- a/README.md
+++ b/README.md
@@ -102,10 +102,13 @@ Each of the quality control microservices uses a `BaroqueProject` object, which 
 ### BaroqueValidator
 Each of the quality control microservices detailed above is a subclass of a base `BaroqueValidator` class, which is defined in `baroque/baroque_validator.py`. The `BaroqueValidator` base class takes as its arguments a name for the validation step, a function to use as a validator, and a `BaroqueProject` object. The `BaroqueValidator` base class implements a few shared functions, including `validate`, which runs the configured validation function, `error`, which adds a requirement error to the `BaroqueProject` object, and `warn`, which adds a warning error to the `BaroqueProject` object. 
 
-#### Validate METS XML specs
+#### Detailed validate directory and file structure specs
 Not yet documented.
 
-#### Validate WAV BEXT chunk specs
+#### Detailed validate METS XML specs
+Not yet documented.
+
+#### Detailed validate WAV BEXT chunk specs
 Not yet documented.
 
 ### Error reports

--- a/README.md
+++ b/README.md
@@ -102,15 +102,6 @@ Each of the quality control microservices uses a `BaroqueProject` object, which 
 ### BaroqueValidator
 Each of the quality control microservices detailed above is a subclass of a base `BaroqueValidator` class, which is defined in `baroque/baroque_validator.py`. The `BaroqueValidator` base class takes as its arguments a name for the validation step, a function to use as a validator, and a `BaroqueProject` object. The `BaroqueValidator` base class implements a few shared functions, including `validate`, which runs the configured validation function, `error`, which adds a requirement error to the `BaroqueProject` object, and `warn`, which adds a warning error to the `BaroqueProject` object. 
 
-#### Detailed validate directory and file structure specs
-Not yet documented.
-
-#### Detailed validate METS XML specs
-Not yet documented.
-
-#### Detailed validate WAV BEXT chunk specs
-Not yet documented.
-
 ### Error reports
 Error reports are generated within `baroque/report_generation.py`. This script checks the `BaroqueProject` object and, if any errors have been found, creates a CSV detailing the validation step in which the error was found, the error type (either a requirement or a warning error), the path to the item or file containing the error, the identifier for the item containing the error, and an error message. The CSV is saved to the destination directory supplied when running BAroQUe and used the filenaming convention `source_directory-timestamp.csv` to avoid duplicate filenames. An error report is not generated if no errors are found.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Not yet implemented.
 Not yet implemented.
 
 ### config.ini
-An optional `config.ini` file can be supplied in the top-level `baroque` directory to supply BAroQUe with a path to a destination directory where reports will be saved and various tools. See `config-sample.ini` for an example of what this file should look like.
+An optional `config.ini` file can be supplied in the top-level `baroque` directory to supply BAroQUe with a path to a destination directory where reports will be saved and various tools. See below or the `config-sample.ini` for an example of what this file should look like. 
 
 ```ini
 [reports]
@@ -101,6 +101,12 @@ Each of the quality control microservices uses a `BaroqueProject` object, which 
 
 ### BaroqueValidator
 Each of the quality control microservices detailed above is a subclass of a base `BaroqueValidator` class, which is defined in `baroque/baroque_validator.py`. The `BaroqueValidator` base class takes as its arguments a name for the validation step, a function to use as a validator, and a `BaroqueProject` object. The `BaroqueValidator` base class implements a few shared functions, including `validate`, which runs the configured validation function, `error`, which adds a requirement error to the `BaroqueProject` object, and `warn`, which adds a warning error to the `BaroqueProject` object. 
+
+#### Validate METS XML specs
+Not yet documented.
+
+#### Validate WAV BEXT chunk specs
+Not yet documented.
 
 ### Error reports
 Error reports are generated within `baroque/report_generation.py`. This script checks the `BaroqueProject` object and, if any errors have been found, creates a CSV detailing the validation step in which the error was found, the error type (either a requirement or a warning error), the path to the item or file containing the error, the identifier for the item containing the error, and an error message. The CSV is saved to the destination directory supplied when running BAroQUe and used the filenaming convention `source_directory-timestamp.csv` to avoid duplicate filenames. An error report is not generated if no errors are found.

--- a/baroque.py
+++ b/baroque.py
@@ -23,16 +23,17 @@ def main():
     parser.add_argument("-c", "--checksums", action="store_true", help="Validate checksums")
     args = parser.parse_args()
 
-    config = configparser.ConfigParser()
-    config.read("config.ini")
     if args.destination:
         project = BaroqueProject(args.source, args.destination, args.export)
-    elif config["reports"]["path"]:
-        project = BaroqueProject(args.source, config["reports"]["path"], args.export)
     else:
-        if not os.path.isdir("reports"):
-            os.mkdir("reports")
-        project = BaroqueProject(args.source, "reports", args.export)
+        try:
+            config = configparser.ConfigParser()
+            config.read("config.ini")
+            project = BaroqueProject(args.source, config["reports"]["path"], args.export)
+        except:
+            if not os.path.isdir("reports"):
+                os.mkdir("reports")
+            project = BaroqueProject(args.source, "reports", args.export)
         
     if (args.structure or args.mets or args.wav) and not args.export:
         print("SYSTEM ERROR: metadata export [-e] is required for directory and file structure, METS validation and WAV BEXT chunks validations")

--- a/baroque.py
+++ b/baroque.py
@@ -30,7 +30,9 @@ def main():
     elif config["reports"]["path"]:
         project = BaroqueProject(args.source, config["reports"]["path"], args.export)
     else:
-        project = BaroqueProject(args.source, os.path.join("reports"), args.export)
+        if not os.path.isdir("reports"):
+            os.mkdir("reports")
+        project = BaroqueProject(args.source, "reports", args.export)
         
     if (args.structure or args.mets or args.wav) and not args.export:
         print("SYSTEM ERROR: metadata export [-e] is required for directory and file structure, METS validation and WAV BEXT chunks validations")

--- a/baroque.py
+++ b/baroque.py
@@ -1,4 +1,6 @@
 import argparse
+import configparser
+import os
 
 from baroque.baroque_project import BaroqueProject
 from baroque.checksum_validation import ChecksumValidator
@@ -12,7 +14,7 @@ from baroque.wav_bext_chunk_validation import WavBextChunkValidator
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("source", help="Path to source directory")
-    parser.add_argument("destination", help="Path to destination for reports")
+    parser.add_argument("-d", "--destination", help="Path to destination for reports")
     parser.add_argument("-s", "--structure", action="store_true", help="Validate directory and file structure")
     parser.add_argument("-e", "--export", help="Path to metadata export")
     parser.add_argument("-m", "--mets", action="store_true", help="Validate METS")
@@ -21,10 +23,17 @@ def main():
     parser.add_argument("-c", "--checksums", action="store_true", help="Validate checksums")
     args = parser.parse_args()
 
-    project = BaroqueProject(args.source, args.destination, args.export)
-
-    if (args.structure or args.mets) and not args.export:
-        print("SYSTEM ERROR: metadata export [-e] is required for structure and METS validation")
+    config = configparser.ConfigParser()
+    config.read("config.ini")
+    if args.destination:
+        project = BaroqueProject(args.source, args.destination, args.export)
+    elif config["reports"]["path"]:
+        project = BaroqueProject(args.source, config["reports"]["path"], args.export)
+    else:
+        project = BaroqueProject(args.source, os.path.join("reports"), args.export)
+        
+    if (args.structure or args.mets or args.wav) and not args.export:
+        print("SYSTEM ERROR: metadata export [-e] is required for directory and file structure, METS validation and WAV BEXT chunks validations")
         sys.exit()
 
     if args.structure:

--- a/baroque/.gitignore
+++ b/baroque/.gitignore
@@ -1,0 +1,2 @@
+config.ini
+reports/

--- a/baroque/.gitignore
+++ b/baroque/.gitignore
@@ -1,2 +1,0 @@
-config.ini
-reports/

--- a/baroque/baroque_validator.py
+++ b/baroque/baroque_validator.py
@@ -7,9 +7,7 @@ class BaroqueValidator:
             self.project.errors[validation] = []
 
     def validate(self):
-        print("SYSTEM ACTIVITY: starting {}".format(self.validation))
         self.validator()
-        print("SYSTEM ACTIVITY: ending {}".format(self.validation))
     
     def error(self, path, id, message):
         error_type = "requirement"

--- a/baroque/mets_validation.py
+++ b/baroque/mets_validation.py
@@ -384,7 +384,7 @@ class MetsValidator(BaroqueValidator):
         """
         Validates METS"""
 
-        for item in tqdm(self.project.items):
+        for item in tqdm(self.project.items, desc="METS Validation"):
 
             # Assuming for now that validating directory and file structure would have picked this up
             if not item['files']['xml']:

--- a/baroque/structure_validation.py
+++ b/baroque/structure_validation.py
@@ -99,7 +99,7 @@ class StructureValidator(BaroqueValidator):
         # List of files that are checked.
         check_files = ["jpg", "xml", "txt", "other"]
 
-        for item in tqdm(self.project.items, desc="Structure Validation"):
+        for item in tqdm(self.project.items, desc="Directory and File Structure Validation"):
             min_output = {}
             max_output = {}
             other_output = []

--- a/baroque/structure_validation.py
+++ b/baroque/structure_validation.py
@@ -99,7 +99,7 @@ class StructureValidator(BaroqueValidator):
         # List of files that are checked.
         check_files = ["jpg", "xml", "txt", "other"]
 
-        for item in tqdm(self.project.items):
+        for item in tqdm(self.project.items, desc="Structure Validation"):
             min_output = {}
             max_output = {}
             other_output = []

--- a/baroque/utils.py
+++ b/baroque/utils.py
@@ -9,6 +9,11 @@ def sanitize_text(text):
     else:
         text = re.sub(r"\n", " ", text)
         text = re.sub(r"\s+", " ", text)
-        text = text.replace('“', '"').replace('”', '"')
+        text = text.replace('“', '"').replace('”', '"').replace('"', "")
+        text = text.replace("'", "")
+        text = text.replace("-", "")
+        text = text.replace(";", "")
+        text = text.replace("…", "")
+        text = text.replace ("&", "and")
         text = text.strip()
         return text

--- a/baroque/wav_bext_chunk_validation.py
+++ b/baroque/wav_bext_chunk_validation.py
@@ -99,7 +99,7 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
         Helper function to see if WAV BEXT chunk Coding History subelement matches an expected value"""
         for coding_history in coding_histories:
             for subelement_tag, subelement_text in coding_history.items():
-                if subelement_tag == tag and subelement_text not in values:
+                if subelement_tag == tag and sanitize_text(subelement_text) not in values:
                     self.error(
                         path_to_wav,
                         self.item_id,

--- a/baroque/wav_bext_chunk_validation.py
+++ b/baroque/wav_bext_chunk_validation.py
@@ -64,6 +64,22 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
                 self.item_id,
                 metadatum + " value of " + row[metadatum] + " is not datetime"
             )
+    
+    def check_coding_history(self, path_to_wav, row):
+        # "A=ANALOGUE,M=mono,T=Studer A-810; 7.5 ips; open reel
+        # A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D"
+        self.check_bext_metadatum_exists(path_to_wav, row, "CodingHistory")
+        if row.get("CodingHistory"):
+            coding_histories = []
+            for coding_history_line in row["CodingHistory"].splitlines():
+                if coding_history_line:
+                    coding_history = {}
+                    subelements = coding_history_line.split(",")
+                    for subelement in subelements:
+                        subelement_tag = subelement.split("=")[0]
+                        subelement_text = subelement.split("=")[1]
+                        coding_history[subelement_tag] = subelement_text
+                    coding_histories.append(coding_history)
 
     def validate_bwfmetaedit_csv(self, path_to_wav, bwfmetaedit_csv):
         with io.StringIO(bwfmetaedit_csv.decode("utf-8")) as f:
@@ -88,7 +104,10 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
                 self.check_bext_metadatum_value_is_datetime(path_to_wav, row, "OriginationTime")
 
                 self.check_bext_metadatum_exists(path_to_wav, row, "TimeReference")
-                self.check_bext_metadatum_exists(path_to_wav, row, "CodingHistory")
+                # self.check_bext_metadatum_exists(path_to_wav, row, "CodingHistory")
+
+                self.check_coding_history(path_to_wav, row)
+
 
     def validate_wav_bext_chunks(self):
         """ 

--- a/baroque/wav_bext_chunk_validation.py
+++ b/baroque/wav_bext_chunk_validation.py
@@ -94,7 +94,7 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
         """ 
         Validates WAV BEXT chunks """
 
-        for item in tqdm(self.project.items):
+        for item in tqdm(self.project.items, desc="WAV BEXT Chunk Validation"):
             paths_to_wavs = self.get_paths_to_wavs(item)
             for path_to_wav in paths_to_wavs: 
                 bwfmetaedit_csv = self.get_bwfmetaedit_csv(path_to_wav)

--- a/baroque/wav_bext_chunk_validation.py
+++ b/baroque/wav_bext_chunk_validation.py
@@ -88,6 +88,7 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
                         tag + " field value " + subelement_text + " not in " + str(values)
                     )
 
+    
     def check_coding_history_subelements(self, path_to_wav, row):
         # "A=ANALOGUE,M=mono,T=Studer A-810; 7.5 ips; open reel
         # A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D"
@@ -135,6 +136,7 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
 
             self.check_num_coding_history_subelement_is_at_least_one(path_to_wav, coding_histories, "T")
 
+    
     def validate_bwfmetaedit_csv(self, path_to_wav, bwfmetaedit_csv):
         with io.StringIO(bwfmetaedit_csv.decode("utf-8")) as f:
             reader = csv.DictReader(f)

--- a/baroque/wav_bext_chunk_validation.py
+++ b/baroque/wav_bext_chunk_validation.py
@@ -64,7 +64,30 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
                 self.item_id,
                 metadatum + " value of " + row[metadatum] + " is not datetime"
             )
+
+    def check_num_coding_history_subelement_is_at_least_one(self, path_to_wav, coding_histories, tag):
+        subelement_num = 0
+        for coding_history in coding_histories:
+            for subelement_tag, _ in coding_history.items():
+                if subelement_tag == tag:
+                    subelement_num += 1
+        if subelement_num == 0:
+            self.error(
+                path_to_wav,
+                self.item_id,
+                "no " + tag + " field in coding history"
+            )
     
+    def check_coding_history_subelement_value(self, path_to_wav, coding_histories, tag, values):
+        for coding_history in coding_histories:
+            for subelement_tag, subelement_text in coding_history.items():
+                if subelement_tag == tag and subelement_text not in values:
+                    self.error(
+                        path_to_wav,
+                        self.item_id,
+                        tag + " field value " + subelement_text + " not in " + str(values)
+                    )
+
     def check_coding_history_subelements(self, path_to_wav, row):
         # "A=ANALOGUE,M=mono,T=Studer A-810; 7.5 ips; open reel
         # A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D"
@@ -98,94 +121,19 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
                             self.item_id,
                             subelement_tag + " not in list of acceptable coding history subelement tags"
                         )
-            # BEXT chunk "Coding History" field must have at least one A field
-            coding_algorithms = 0
-            for coding_history in coding_histories:
-                for subelement_tag, _ in coding_history.items():
-                    if subelement_tag == "A":
-                        coding_algorithms += 1
-            if coding_algorithms == 0:
-                self.error(
-                    path_to_wav,
-                    self.item_id,
-                    "no coding algorithm (a) field in coding history"
-                )
-            # BEXT chunk "Coding History" field A must be "ANALOG" or "PCM"
-            for coding_history in coding_histories:
-                for subelement_tag, subelement_text in coding_history.items():
-                    if subelement_tag == "A" and subelement_text not in ["ANALOGUE", "PCM"]:
-                        self.error(
-                            path_to_wav,
-                            self.item_id,
-                            "coding algorithm (a) field value not ANALOGUE or PCM"
-                        )
-            # BEXT chunk "Coding History" field must have at least one F field
-            sampling_frequencies = 0
-            for coding_history in coding_histories:
-                for subelement_tag, _ in coding_history.items():
-                    if subelement_tag == "F":
-                        sampling_frequencies += 1
-            if sampling_frequencies == 0:
-                self.error(
-                    path_to_wav,
-                    self.item_id,
-                    "no sampling frequency (f) field in coding history"
-                )
-            # BEXT chunk "Coding History" field F must be 9600
-            for coding_history in coding_histories:
-                for subelement_tag, subelement_text in coding_history.items():
-                    if subelement_tag == "F" and subelement_text != "96000":
-                        self.error(
-                            path_to_wav,
-                            self.item_id,
-                            "sampling frequency (f) field value not 96000"
-                        )
-            # BEXT chunk "Coding History" field must have at least one W field
-            word_lengths = 0
-            for coding_history in coding_histories:
-                for subelement_tag, _ in coding_history.items():
-                    if subelement_tag == "F":
-                        word_lengths += 1
-            if word_lengths == 0:
-                self.error(
-                    path_to_wav,
-                    self.item_id,
-                    "no word length (w) field in coding history"
-                )
-            # BEXT chunk "Coding History" field W must be 9600
-            for coding_history in coding_histories:
-                for subelement_tag, subelement_text in coding_history.items():
-                    if subelement_tag == "W" and subelement_text != "24":
-                        self.error(
-                            path_to_wav,
-                            self.item_id,
-                            "word length (w) field value not 24"
-                        )
-            # BEXT chunk "Coding History" field must have at least one M field
-            modes = 0
-            for coding_history in coding_histories:
-                for subelement_tag, _ in coding_history.items():
-                    if subelement_tag == "M":
-                        modes += 1
-            if modes == 0:
-                self.error(
-                    path_to_wav,
-                    self.item_id,
-                    "no mode (m) field in coding history"
-                )
-            # BEXT chunk "Coding History" field must have at least one T field
-            free_ascii_text_strings = 0
-            for coding_history in coding_histories:
-                for subelement_tag, _ in coding_history.items():
-                    if subelement_tag == "T":
-                        free_ascii_text_strings += 1
-            if free_ascii_text_strings == 0:
-                self.error(
-                    path_to_wav,
-                    self.item_id,
-                    "no free ascii text string (t) field in coding history"
-                )
             
+            self.check_num_coding_history_subelement_is_at_least_one(path_to_wav, coding_histories, "A")
+            self.check_coding_history_subelement_value(path_to_wav, coding_histories, "A", ["ANALOGUE", "PCM"])
+
+            self.check_num_coding_history_subelement_is_at_least_one(path_to_wav, coding_histories, "F")
+            self.check_coding_history_subelement_value(path_to_wav, coding_histories, "F", ["96000"])
+            
+            self.check_num_coding_history_subelement_is_at_least_one(path_to_wav, coding_histories, "W")
+            self.check_coding_history_subelement_value(path_to_wav, coding_histories, "W", ["24"])
+
+            self.check_num_coding_history_subelement_is_at_least_one(path_to_wav, coding_histories, "M")
+
+            self.check_num_coding_history_subelement_is_at_least_one(path_to_wav, coding_histories, "T")
 
     def validate_bwfmetaedit_csv(self, path_to_wav, bwfmetaedit_csv):
         with io.StringIO(bwfmetaedit_csv.decode("utf-8")) as f:

--- a/baroque/wav_bext_chunk_validation.py
+++ b/baroque/wav_bext_chunk_validation.py
@@ -1,3 +1,4 @@
+import configparser
 import csv
 import dateparser
 import os
@@ -35,7 +36,12 @@ class WavBextChunkValidator(BaroqueValidator):
         R:\\BAroQUe\\2019012\\0648\\0648-SR-4\\0648-SR-4-1-2-am.wav,Paul Phillips (Tape No. 4),"US, MiU-H",MiU-H_0648-SR-4-1-am,2019-05-20,12:04:58,00:47:59.000,276384000,1,,,,,,,"A=ANALOGUE,M=mono,T=Studer A-810; 7.5 ips; open reel
 A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan",,,,,,,,,Reel-to-reel; 7 inch; Sony; None; Polyester"""
 
-        bwfmetaedit_csv = subprocess.check_output(["./tools/bwfmetaedit.exe", "--out-core", path_to_wav], stderr=subprocess.STDOUT)
+        try:
+            config = configparser.ConfigParser()
+            config.read(os.path.join(".", "config.ini"))
+            bwfmetaedit_csv = subprocess.check_output([os.path.join(".", config["bwf_metaedit"]["path"]), "--out-core", path_to_wav], stderr=subprocess.STDOUT)
+        except: 
+            bwfmetaedit_csv = subprocess.check_output(["./tools/bwfmetaedit.exe", "--out-core", path_to_wav], stderr=subprocess.STDOUT)
 
         return bwfmetaedit_csv
 

--- a/baroque/wav_bext_chunk_validation.py
+++ b/baroque/wav_bext_chunk_validation.py
@@ -65,7 +65,7 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
                 metadatum + " value of " + row[metadatum] + " is not datetime"
             )
     
-    def check_coding_history(self, path_to_wav, row):
+    def check_coding_history_subelements(self, path_to_wav, row):
         # "A=ANALOGUE,M=mono,T=Studer A-810; 7.5 ips; open reel
         # A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D"
         self.check_bext_metadatum_exists(path_to_wav, row, "CodingHistory")
@@ -210,9 +210,8 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
                 self.check_bext_metadatum_value_is_datetime(path_to_wav, row, "OriginationTime")
 
                 self.check_bext_metadatum_exists(path_to_wav, row, "TimeReference")
-                # self.check_bext_metadatum_exists(path_to_wav, row, "CodingHistory")
 
-                self.check_coding_history(path_to_wav, row)
+                self.check_coding_history_subelements(path_to_wav, row)
 
 
     def validate_wav_bext_chunks(self):

--- a/config-sample.ini
+++ b/config-sample.ini
@@ -1,2 +1,2 @@
 [reports]
-path=C:\Users\eckardm\Desktop\baroque_reports
+path=path\to\reports

--- a/config-sample.ini
+++ b/config-sample.ini
@@ -1,2 +1,5 @@
 [reports]
 path=path\to\reports
+
+[bwf_metaedit]
+path=path\to\bwfmetaedit.exe

--- a/config-sample.ini
+++ b/config-sample.ini
@@ -1,0 +1,2 @@
+[reports]
+path=C:\Users\eckardm\Desktop\baroque_reports


### PR DESCRIPTION
Changes proposed in this pull request included:
- Checks not only that a WAV BEXT chunk metadata element exists, but also that it has value
- Validates `CodingHistory` subelements according to the A/V QC Utility Requirements spreadsheet
- Makes the destination directory for BAroQUe reports configurable: This means that the destination argument is now optional (`-d, --destination`). If there's no destination, BAroQue checks the config file. If there's no config file or no path set in the config file, BAroQUe defaults to a "/reports" directory. All of this is ignored by version control. The path to "bwfmetaedit.exe" is also configurable. 
- `sanitize_text()` in "utils.py" does some additional sanitization. This doesn't help with every instance, but significantly reduces the amount of times where yes, _technically_ the metadata export title doesn't match the WAV BEXT chunk `Description`, but really they do
- Makes what prints to the terminal more minimalist

Before submitting a pull request, confirm that the following steps have been taken:
- [ ] Added unit tests
- [x] Updated documentation, including README, comments in functions and `config-sample.ini`

Tag someone who should review this pull request:
@djpillen @hyeeyoungkim 
