### PR TITLE
Reduce errors when run on a collection or item

### DIFF
--- a/baroque/baroque_project.py
+++ b/baroque/baroque_project.py
@@ -54,7 +54,7 @@ class BaroqueProject(object):
     }
     """
 
-    def __init__(self, source_directory, destination_directory, metadata_export=None):
+    def __init__(self, source_directory, destination_directory, metadata_export):
         if not os.path.exists(source_directory):
             print("SYSTEM ERROR: source_directory does not exist")
             sys.exit()
@@ -67,14 +67,13 @@ class BaroqueProject(object):
         self.source_directory = source_directory
         self.destination_directory = destination_directory
         self.metadata_export = metadata_export
-        self.errors = {}
-
-        if self.metadata_export:
-            self.metadata = self.parse_metadata_export(metadata_export)
+        
+        self.metadata = self.parse_metadata_export(metadata_export)
 
         self.shipment = []
         self.collections = []
         self.items = []
+        self.errors = {}
 
         self.source_type = self.characterize_source_directory()
         print("SYSTEM REPORT: source_directory is {}".format(self.source_type))


### PR DESCRIPTION
Changes proposed in this pull request included:
- Run `parse_metadata_export` after the source directory has been characterized as a shipment, collection, or item
- If the source directory is an item, only parse entries in the metadata export that match the item id
- If the source directory is a collection, only parse entries in the metadata export that match the collection id

Overall, this PR reduces the number of errors that BAroQUe was reporting when run on only a collection or an item due to it parsing an entire metadata export (often corresponding to an entire shipment) and then checking for all entries in the metadata export, regardless of whether or not the user intended to run BAroQUe on only a subset of a shipment.

Resolves #28  

Tag someone who should review this pull request:
@eckardm @hyeeyoungkim 
