### PR TITLE
do a bit of clean up on the input when configuring a default reports dir

### DIFF
--- a/baroque/config.py
+++ b/baroque/config.py
@@ -28,7 +28,8 @@ def _load_config():
 
 
 def _create_config(config, config_file):
-    reports_dir = input("Enter a default reports directory: ").strip()
+    reports_dir_input = input("Enter a default reports directory: ")
+    reports_dir = os.path.normpath(reports_dir_input.strip('"\' '))
     config.add_section("defaults")
     config.set("defaults", "destination", reports_dir)
     _save_config(config, config_file)


### PR DESCRIPTION
Changes proposed in this pull request included:
- Strips single quotes and double quotes from `reports_dir_input` and passes it through `os.path.normpath` for good measure. Resolves #36 

Tag someone who should review this pull request:
@eckardm @mhdezd 
