### PR TITLE
add an all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ $ baroque.py SOURCE_DIR EXPORT_DIR -d/--destination /path/to/reports -w/--wav
 This steps runs all validation checks described above.
  
 ```sh
-$ baroque.py SOURCE_DIR EXPORT_DIR -smw
+$ baroque.py SOURCE_DIR EXPORT_DIR --all
 ```
 
 _or, with the optional destination argument..._
 
 ```sh
-$ baroque.py SOURCE_DIR EXPORT_DIR -d/--destination /path/to/reports -smw
+$ baroque.py SOURCE_DIR EXPORT_DIR -d/--destination /path/to/reports --all
 ```
 
 

--- a/baroque.py
+++ b/baroque.py
@@ -14,10 +14,34 @@ def main():
     parser.add_argument("source", help="Path to source directory")
     parser.add_argument("export", help="Path to metadata export")
     parser.add_argument("-d", "--destination", help="Path to destination for reports")
-    parser.add_argument("-s", "--structure", action="store_true", help="Validate directory and file structure")
-    parser.add_argument("-m", "--mets", action="store_true", help="Validate METS")
-    parser.add_argument("-w", "--wav", action="store_true", help="Validate WAV BEXT chunks")
+
+    action_args = parser.add_argument_group("actions")
+    action_args.add_argument(
+                            "-s", "--structure", dest="actions",
+                            action="append_const", const="structure",
+                            help="Validate directory and file structure"
+                            )
+    action_args.add_argument(
+                            "-m", "--mets", dest="actions",
+                            action="append_const", const="mets",
+                            help="Validate METS"
+                            )
+    action_args.add_argument(
+                            "-w", "--wav", dest="actions",
+                            action="append_const", const="wav",
+                            help="Validate WAV BEXT chunks"
+                            )
+    action_args.add_argument(
+                            "--all", dest="actions", action="store_const",
+                            const=["structure", "mets", "wav"],
+                            help="Run all validations"
+                            )
     args = parser.parse_args()
+
+    if args.actions:
+        actions = set(args.actions)
+    else:
+        parser.error("Please supply a validation action.")
 
     if args.destination:
         destination = args.destination
@@ -25,11 +49,11 @@ def main():
         destination = get_config_setting("destination", default=defaults.REPORTS_DIR)
 
     project = BaroqueProject(args.source, destination, args.export)
-    if args.structure:
+    if "structure" in actions:
         StructureValidator(project).validate()
-    if args.mets:
+    if "mets" in actions:
         MetsValidator(project).validate()
-    if args.wav:
+    if "wav" in actions:
         WavBextChunkValidator(project).validate()
 
     generate_reports(project)


### PR DESCRIPTION
Changes proposed in this pull request included:
- Group validation action args into an "actions" group to better format help messages (see below)
- Store supplied validation actions in an "actions" list
- Add an `--all` option to run all three validation actions at once
- Parse the `args.actions` list to:
  - Take the set of supplied actions. This will ensure that supplying actions one or more times, e.g. `-smw`, `--all`, `-s -m -w --all`, etc. will all result in the specified actions being run only once
  - Display an error message along with the argparse usage info if no actions are specified
  - Run the validators based on whether or not each validation action appears in the actions list instead of checking for args.structure, args.mets, or args.wav

Here's the updated output of `python baroque.py --help`:
```
usage: baroque.py [-h] [-d DESTINATION] [-s] [-m] [-w] [--all] source export

positional arguments:
  source                Path to source directory
  export                Path to metadata export

optional arguments:
  -h, --help            show this help message and exit
  -d DESTINATION, --destination DESTINATION
                        Path to destination for reports

actions:
  -s, --structure       Validate directory and file structure
  -m, --mets            Validate METS
  -w, --wav             Validate WAV BEXT chunks
  --all                 Run all validations
```

Before submitting a pull request, confirm that the following steps have been taken:
- [x] Updated documentation

Tag someone who should review this pull request:
@eckardm @hyeeyoungkim 

Resolves #38 
