### PR TITLE
Accommodate inconsistently named column headers in metadata export

### DIFF
--- a/baroque/baroque_project.py
+++ b/baroque/baroque_project.py
@@ -248,6 +248,10 @@ class BaroqueProject(object):
                 if column_headers[header] not in keys:
                     print("SYSTEM WARNING: '{}' column not found in metadata export".format(column_headers[header]))
                     column_headers[header] = input("Type the column name for '{}' values and press Enter: ".format(column_headers[header]))
+                    if column_headers[header] in keys:
+                        print("SYSTEM REPORT: '{}' column found, proceeding as usual".format(column_headers[header]))
+                    else:
+                        print("SYSTEM REPORT: '{}' column not found, will not compare".format(column_headers[header]))
 
             item_id_column = column_headers["item_id_column"]
             collection_title_column = column_headers["collection_title_column"]

--- a/baroque/baroque_project.py
+++ b/baroque/baroque_project.py
@@ -269,7 +269,6 @@ class BaroqueProject(object):
                 if self.source_type == "collection" and collection_id not in [collection["id"] for collection in self.collections]:
                     continue
                 collection_title = row.get(collection_title_column)
-                self.check_values_exist("collection title", collection_title, row_counter)
                 item_title = row.get(item_title_column)
                 item_date = row.get(item_date_column)
                 metadata["items_ids"].append(item_id)

--- a/baroque/wav_bext_chunk_validation.py
+++ b/baroque/wav_bext_chunk_validation.py
@@ -62,7 +62,7 @@ A=PCM,F=96000,W=24,M=mono,T=Antelope Audio;Orion 32;A/D",,,,,,,"Schreibeis, Ryan
             self.error(
                 path_to_wav,
                 self.item_id,
-                metadatum + " value of " + row[metadatum] + " in bext chunk does not equal " + value
+                metadatum + " value of " + row[metadatum] + " in bext chunk does not equal {}".format(value)
             )
 
     def check_bext_metadatum_value_is_datetime(self, path_to_wav, row, metadatum):


### PR DESCRIPTION
Changes proposed in this pull request include:
- Check that "DigFile Calc," "COLLECTIONS::CollectionTitle," "ItemTitle," and "ItemDate" columns exist in the metadata export.
- Create the option to input the name of an equivalent column in the terminal, if one of the expected columns does not exist.
- Exit the program if there are any item id (DigFile Calc) values missing. These values are required.
- Do not require "COLLECTIONS::CollectionTitle," "ItemTitle," and "ItemDate" columns and values.

Resolves #16

Before submitting a pull request, confirm that the following steps have been taken:
- [x] Reviewed documentation
- [ ] Updated documentation

Tag someone who should review this pull request:
@eckardm 
